### PR TITLE
GlobalExceptionHandler에서 에러 로깅 중 타입 캐스팅 버그 해결

### DIFF
--- a/src/main/kotlin/com/ohforbidden/BugreportApplication.kt
+++ b/src/main/kotlin/com/ohforbidden/BugreportApplication.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport
+package com.ohforbidden
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/com/ohforbidden/controller/Test.kt
+++ b/src/main/kotlin/com/ohforbidden/controller/Test.kt
@@ -1,5 +1,7 @@
-package com.ohforbidden.bugreport.controller
+package com.ohforbidden.controller
 
+import com.ohforbidden.global.exception.BusinessException
+import com.ohforbidden.global.exception.CommonErrorType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -10,5 +12,8 @@ class Test {
     @GetMapping
     fun filterTestTrigger() {
         println("### Controller Works!! ###")
+//        throw RuntimeException("### Controller Throws!! ###")
+
+        throw BusinessException(CommonErrorType.SERVER_ERROR)
     }
 }

--- a/src/main/kotlin/com/ohforbidden/domain/user/User.kt
+++ b/src/main/kotlin/com/ohforbidden/domain/user/User.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.domain.user
+package com.ohforbidden.domain.user
 
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue

--- a/src/main/kotlin/com/ohforbidden/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/ohforbidden/domain/user/UserRepository.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.domain.user
+package com.ohforbidden.domain.user
 
 import org.springframework.data.jpa.repository.JpaRepository
 

--- a/src/main/kotlin/com/ohforbidden/global/config/WebConfig.kt
+++ b/src/main/kotlin/com/ohforbidden/global/config/WebConfig.kt
@@ -1,6 +1,6 @@
-package com.ohforbidden.bugreport.global.config
+package com.ohforbidden.global.config
 
-import com.ohforbidden.bugreport.global.filter.MDCLoggingFilter
+import com.ohforbidden.global.filter.MDCLoggingFilter
 import jakarta.servlet.Filter
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
@@ -21,6 +21,7 @@ class WebConfig() : WebMvcConfigurer {
     fun mdcLoggingFilter(): FilterRegistrationBean<Filter> {
         val filterRegistrationBean = FilterRegistrationBean<Filter>()
         filterRegistrationBean.filter = MDCLoggingFilter()
+        filterRegistrationBean.order = 1
         filterRegistrationBean.addUrlPatterns("/*")
         return filterRegistrationBean
     }

--- a/src/main/kotlin/com/ohforbidden/global/dto/ErrorResponse.kt
+++ b/src/main/kotlin/com/ohforbidden/global/dto/ErrorResponse.kt
@@ -1,6 +1,6 @@
-package com.ohforbidden.bugreport.global.dto
+package com.ohforbidden.global.dto
 
-import com.ohforbidden.bugreport.global.util.createUtcDateTime
+import com.ohforbidden.global.util.createUtcDateTime
 import java.time.ZonedDateTime
 
 data class ErrorResponse(

--- a/src/main/kotlin/com/ohforbidden/global/exception/BusinessException.kt
+++ b/src/main/kotlin/com/ohforbidden/global/exception/BusinessException.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.global.exception
+package com.ohforbidden.global.exception
 
 class BusinessException(
     val errorType: ErrorType,

--- a/src/main/kotlin/com/ohforbidden/global/exception/CommonErrorType.kt
+++ b/src/main/kotlin/com/ohforbidden/global/exception/CommonErrorType.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.global.exception
+package com.ohforbidden.global.exception
 
 import org.springframework.http.HttpStatus
 

--- a/src/main/kotlin/com/ohforbidden/global/exception/ErrorType.kt
+++ b/src/main/kotlin/com/ohforbidden/global/exception/ErrorType.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.global.exception
+package com.ohforbidden.global.exception
 
 import org.springframework.http.HttpStatus
 

--- a/src/main/kotlin/com/ohforbidden/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/ohforbidden/global/exception/GlobalExceptionHandler.kt
@@ -1,7 +1,7 @@
-package com.ohforbidden.bugreport.global.exception
+package com.ohforbidden.global.exception
 
-import com.ohforbidden.bugreport.global.dto.ErrorResponse
-import com.ohforbidden.bugreport.global.util.createUtcDateTime
+import com.ohforbidden.global.dto.ErrorResponse
+import com.ohforbidden.global.util.createUtcDateTime
 import mu.KotlinLogging
 import org.hibernate.exception.ConstraintViolationException
 import org.slf4j.MDC

--- a/src/main/kotlin/com/ohforbidden/global/filter/MDCLoggingFilter.kt
+++ b/src/main/kotlin/com/ohforbidden/global/filter/MDCLoggingFilter.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.global.filter
+package com.ohforbidden.global.filter
 
 import jakarta.servlet.Filter
 import jakarta.servlet.FilterChain

--- a/src/main/kotlin/com/ohforbidden/global/filter/ServletCachingFilter.kt
+++ b/src/main/kotlin/com/ohforbidden/global/filter/ServletCachingFilter.kt
@@ -1,0 +1,25 @@
+package com.ohforbidden.global.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+
+@Component
+class ServletCachingFilter() : OncePerRequestFilter() { // 모든 서블릿 요청에 일관된 필터 적용을 위해 OncePerRequestFilter 사용
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val wrappedRequest = ContentCachingRequestWrapper(request)
+        val wrappedResponse = ContentCachingResponseWrapper(response)
+
+        filterChain.doFilter(wrappedRequest, wrappedResponse)
+        wrappedResponse.copyBodyToResponse() // 해당 부분을 통해 response 다시 읽을 수 있도록 설정
+    }
+}

--- a/src/main/kotlin/com/ohforbidden/global/interceptor/LogInterceptor.kt
+++ b/src/main/kotlin/com/ohforbidden/global/interceptor/LogInterceptor.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.global.interceptor
+package com.ohforbidden.global.interceptor
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/main/kotlin/com/ohforbidden/global/util/TimeUtils.kt
+++ b/src/main/kotlin/com/ohforbidden/global/util/TimeUtils.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.global.util
+package com.ohforbidden.global.util
 
 import java.time.ZoneOffset
 import java.time.ZonedDateTime

--- a/src/main/kotlin/com/ohforbidden/infrastructure/config/JpaConfig.kt
+++ b/src/main/kotlin/com/ohforbidden/infrastructure/config/JpaConfig.kt
@@ -1,4 +1,4 @@
-package com.ohforbidden.bugreport.infrastructure.config
+package com.ohforbidden.infrastructure.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing


### PR DESCRIPTION
# 버그 리포트

## 버그 유형 및 현상
- 에러 발생 시 `GlobalExceptionHandler`를 통해 log를 남기게 된다. 
- 이때 request의 정보를 사용하기 위해 `ContentCachingRequestWrapper`로 타입 캐스팅해주는 과정에서 에러가 발생했다.

## 해결 방법
- `ServletCachingFilter`를 추가하여 내부에서 Request와 Response를 `ContentCachingRequest(Response)Wrapper`로 생성하여 다음 필터로 넘기게 설정해주었다.

## 원인
- 로깅을 하기 위해서는 필터나 인터셉터를 통해서 서블릿 Request, Response를 접근해서 그 content를 읽어야한다.
- 하지만 서블릿은 요청 응답 객체를 단 한번만 읽을 수 있도록 설계되어있다.
- 로깅을 위해서 Reqeust, Response 객체를 여러번 읽기 위한 Wrapper 클래스로 한번 감싸주는 작업을 수행해야 한다.
- 결국 감싸주는 작업을 하지 않고 Wrapper를 사용하려고 해서 타입이 다르기 때문에 캐스팅 에러가 발생했다.

## 참고

> - https://mopil.tistory.com/74
> - https://yangbongsoo.tistory.com/28?category=919800
> - https://velog.io/@blackbean99/HttpContentCache%EC%A0%81%EC%9A%A9%ED%95%98%EC%97%AC-body-%EC%9E%AC%ED%99%9C%EC%9A%A9